### PR TITLE
注释中包含类似<pr/>, maven 错误: 不允许使用自关闭元素

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,15 @@
                 </plugins>
             </build>
         </profile>
+		<profile>
+            <id>disable-java8-doclint</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+        </profile>
     </profiles>
     <build>
         <plugins>
@@ -191,6 +200,18 @@
                     </execution>
                 </executions>
             </plugin>
+			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <compilerArgument>-g</compilerArgument>
+                    <verbose>true</verbose>
+					<encoding>UTF-8</encoding>
+                </configuration>
+			</plugin>
         </plugins>
     </build>
     <distributionManagement>


### PR DESCRIPTION
mvn 编译错误， jdk1.8， 注释中包含类似单行<pr/>元素
